### PR TITLE
Pool has to be terminated after use

### DIFF
--- a/lib/celluloid/pmap.rb
+++ b/lib/celluloid/pmap.rb
@@ -11,7 +11,7 @@ module Celluloid
         def pmap(size=Celluloid.cores, &block)
           pool = Pmap::ParallelMapWorker.pool(size: size)
           futures = map { |elem| pool.future :yielder, elem, &block }
-          futures.map { |future| future.value }
+          futures.map { |future| future.value }.tap { pool.terminate }
         end
 
       end

--- a/lib/celluloid/pmap.rb
+++ b/lib/celluloid/pmap.rb
@@ -11,7 +11,9 @@ module Celluloid
         def pmap(size=Celluloid.cores, &block)
           pool = Pmap::ParallelMapWorker.pool(size: size)
           futures = map { |elem| pool.future :yielder, elem, &block }
-          futures.map { |future| future.value }.tap { pool.terminate }
+          futures.map { |future| future.value }
+        ensure
+          pool.terminate
         end
 
       end


### PR DESCRIPTION
Otherwise I end up with huge numbers of actors when the application crashes, with the database pool completely used...
