### PR TITLE
Update for the new world order.

### DIFF
--- a/celluloid-pmap.gemspec
+++ b/celluloid-pmap.gemspec
@@ -18,8 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency('celluloid', '~> 0.12')
+  gem.add_dependency('celluloid', '~> 0.16')
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
+  gem.add_development_dependency "pry"
 end

--- a/lib/celluloid/pmap.rb
+++ b/lib/celluloid/pmap.rb
@@ -10,7 +10,7 @@ module Celluloid
 
         def pmap(size=Celluloid.cores, &block)
           pool = Pmap::ParallelMapWorker.pool(size: size)
-          futures = map { |elem| pool.future :yielder, elem, &block }
+          futures = map { |elem| pool.future(:yielder, elem, block) }
           futures.map { |future| future.value }
         end
 

--- a/lib/celluloid/pmap.rb
+++ b/lib/celluloid/pmap.rb
@@ -8,8 +8,12 @@ module Celluloid
     def self.included(base)
       base.class_eval do
 
-        def pmap(size=Celluloid.cores, &block)
-          pool = Pmap::ParallelMapWorker.pool(size: size)
+        def pmap(pool_or_size=Celluloid.cores, &block)
+          pool = if pool_or_size.class.ancestors.include?(Celluloid::PoolManager)
+                   pool_or_size
+                 else
+                   Pmap::ParallelMapWorker.pool(size: pool_or_size)
+                 end
           futures = map { |elem| pool.future(:yielder, elem, block) }
           futures.map { |future| future.value }
         end

--- a/lib/celluloid/pmap/parallel_map_worker.rb
+++ b/lib/celluloid/pmap/parallel_map_worker.rb
@@ -4,8 +4,8 @@ module Celluloid::Pmap
   class ParallelMapWorker
     include Celluloid
 
-    def yielder(element=nil, &block)
-      yield element
+    def yielder(element=nil, block)
+      block.call(element)
     end
   end
 

--- a/spec/celluloid/pmap/parallel_map_worker_spec.rb
+++ b/spec/celluloid/pmap/parallel_map_worker_spec.rb
@@ -3,12 +3,12 @@ require 'celluloid/pmap/parallel_map_worker'
 describe Celluloid::Pmap::ParallelMapWorker do
 
   it "should execute the block we send" do
-    result = subject.yielder { 6 + 3 }
+    result = subject.yielder(proc { 6 + 3 })
     result.should eq(9)
   end
 
   it "should send in the argument to the block" do
-    result = subject.yielder(6) {|e| e + 3 }
+    result = subject.yielder(6, ->(e) { e + 3 })
     result.should eq(9)
   end
 end

--- a/spec/celluloid/pmap_spec.rb
+++ b/spec/celluloid/pmap_spec.rb
@@ -40,6 +40,13 @@ describe Celluloid::Pmap do
     }.to take_approximately(1).seconds
   end
 
+  let(:pool) { Celluloid::Pmap::ParallelMapWorker.pool(size: 10) }
+  it 'can reuse an existing thread pool' do
+    expect {
+      [1,2,3,4,5,6].pmap(pool) {|x| x; sleep(1) }
+    }.to take_approximately(1).seconds
+  end
+
   it 'should be included in enumerable' do
     Enumerable.ancestors.should include(Celluloid::Pmap)
   end

--- a/spec/support/benchmark_spec.rb
+++ b/spec/support/benchmark_spec.rb
@@ -1,14 +1,16 @@
 require 'benchmark'
 
-RSpec::Matchers.define :take_approximately do |n|
+RSpec::Matchers.define :take_approximately do |expected|
   chain :seconds do; end
 
   match do |block|
     @elapsed = Benchmark.realtime do
       block.call
     end
-    @elapsed.should be_within(0.2).of(n)
+    @elapsed.should be_within(0.2).of(expected)
   end
+
+  supports_block_expectations
 
   failure_message_for_should do |actual|
     "expected block to take about #{expected} seconds, but took #{@elapsed}"
@@ -19,7 +21,7 @@ RSpec::Matchers.define :take_approximately do |n|
   end
 
   description do
-    "take approximately #{expectely} seconds to execute"
+    "take approximately #{expected} seconds to execute"
   end
 
 end


### PR DESCRIPTION
This is to update to the latest version of Celluloid (explicitly) and RSpec (implicitly). This requires some changes to the code, details of which are provided in the individual commit messages.

Also added the ability to use an externally-created thread pool and pass it to pmap. This solves a problem I was facing when using pmap where it would eventually exhaust all available threads and crash, because it was creating a new thread pool on each invocation.
