### PR TITLE
Add ability to use externally-created thread pool.

### DIFF
--- a/lib/celluloid/pmap.rb
+++ b/lib/celluloid/pmap.rb
@@ -8,8 +8,12 @@ module Celluloid
     def self.included(base)
       base.class_eval do
 
-        def pmap(size=Celluloid.cores, &block)
-          pool = Pmap::ParallelMapWorker.pool(size: size)
+        def pmap(pool_or_size=Celluloid.cores, &block)
+          pool = if pool_or_size.class.ancestors.include?(Celluloid::PoolManager)
+                   pool_or_size
+                 else
+                   Pmap::ParallelMapWorker.pool(size: pool_or_size)
+                 end
           futures = map { |elem| pool.future(:yielder, elem, block) }
           futures.map { |future| future.value }
         end

--- a/spec/celluloid/pmap_spec.rb
+++ b/spec/celluloid/pmap_spec.rb
@@ -40,6 +40,13 @@ describe Celluloid::Pmap do
     }.to take_approximately(1).seconds
   end
 
+  let(:pool) { Celluloid::Pmap::ParallelMapWorker.pool(size: 10) }
+  it 'can reuse an existing thread pool' do
+    expect {
+      [1,2,3,4,5,6].pmap(pool) {|x| x; sleep(1) }
+    }.to take_approximately(1).seconds
+  end
+
   it 'should be included in enumerable' do
     Enumerable.ancestors.should include(Celluloid::Pmap)
   end


### PR DESCRIPTION
If you pass a Celluloid::PoolManager object to pmap, it will use that as its thread pool. If you pass no arguments or a numeric size, it will behave as it always has and create a new thread pool an each invocation.

The motivation for this change is that when `pmap` is called frequently, it ends up creating a new pool each time. When using a large thread pool size this led to exhaustion of resources and runtime exceptions.
