### PR TITLE
Fixed a incorrect check for version number 

### DIFF
--- a/lib/celluloid/pmap.rb
+++ b/lib/celluloid/pmap.rb
@@ -4,27 +4,30 @@ require "celluloid/pmap/version"
 module Celluloid
   module Pmap
 
-    
+    def self.find_loaded_gem(name)
+      Gem.loaded_specs.values.detect{|repo| repo.name == name }
+    end
+
     def self.pool_class
-      celluloid_version =  Celluloid::VERSION.to_s.split('.')
-      if celluloid_version[0].to_i >= 0 && celluloid_version[1].to_i <= 16
+      celluloid_version = find_loaded_gem("celluloid").version.to_s.split('.')
+      if celluloid_version[0].to_i == 0 && celluloid_version[1].to_i <= 16
         require 'celluloid'
         Celluloid::PoolManager
       else
-          require 'celluloid/current' 
+        require 'celluloid/current'
         Celluloid::Supervision::Container::Pool
-      end 
+      end
     end
-    
+
     def self.included(base)
       base.class_eval do
 
         def pmap(pool_or_size=Celluloid.cores, &block)
           pool = if pool_or_size.class.ancestors.include?(Celluloid::Pmap.pool_class)
-                   pool_or_size
-                 else
-                   Pmap::ParallelMapWorker.pool(size: pool_or_size)
-                 end
+            pool_or_size
+          else
+            Pmap::ParallelMapWorker.pool(size: pool_or_size)
+          end
           futures = map { |elem| pool.future(:yielder, elem, block) }
           futures.map { |future| future.value }
         end


### PR DESCRIPTION
Hello, 
 I fixed a incorrect check for version number of celluloid gem that was introduced in this pull request: https://github.com/jwo/celluloid-pmap/pull/8  .

Also i added a new method for getting the celluloid gem specification because i realised in some cases the Celluloid::VERSION can be undefined because is only gets defined after celluloid gem is required.

Sorry for the trouble. I checked and re-checked again and now seems to work properly. 
